### PR TITLE
Update switch.py

### DIFF
--- a/custom_components/momentary/switch.py
+++ b/custom_components/momentary/switch.py
@@ -120,7 +120,7 @@ class MomentarySwitch(SwitchEntity):
         self._activate("off")
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the device state attributes."""
         attrs = {
             'friendly_name': self._name,


### PR DESCRIPTION
Since 2021.12 device_state_attributes is deprecated and need to be replaced by extra_state_attributes.